### PR TITLE
Fix password reset form button styling

### DIFF
--- a/src/views/User/PasswordReset.vue
+++ b/src/views/User/PasswordReset.vue
@@ -33,7 +33,7 @@
           expanded
         />
       </o-field>
-      <p class="my-4 flex gap-2">
+      <p class="my-4">
         <o-button
           variant="primary"
           size="large"


### PR DESCRIPTION
Visual fixes for password reset submit button. We use the `<o-button/>` component instead of the plain HTML that was there before, giving it the proper styling.

## Previews

### Before
![image](https://github.com/user-attachments/assets/9474b47c-60d0-4d27-8ec6-4957ca01fa28)

### After
![image](https://github.com/user-attachments/assets/6fc9156d-4272-4cda-bc10-5abee3d9882d)
