### PR TITLE
Use browsers in Sweden specifically for browserslist

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,1 +1,1 @@
-> 0.25% and last 2 versions, not dead, not ie 11, not op_mini all, Firefox ESR
+> 0.25% in SE, last 2 versions, not dead, not ie 11, not op_mini all, Firefox ESR


### PR DESCRIPTION
Our target audience are Sweden, and so our target browsers should be the ones in Sweden.