### PR TITLE
get rid of grid gaps

### DIFF
--- a/src/components/Event/MultiCard.vue
+++ b/src/components/Event/MultiCard.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="grid auto-rows-[1fr] gap-x-2 gap-y-4 md:gap-x-6 grid-cols-[repeat(auto-fill,_minmax(250px,_1fr))] justify-items-center"
+    class="grid gap-x-2 gap-y-4 md:gap-x-6 grid-cols-[repeat(auto-fill,_minmax(250px,_1fr))] justify-items-center"
   >
     <event-card
       class="flex flex-col h-full"

--- a/src/components/Group/MultiGroupCard.vue
+++ b/src/components/Group/MultiGroupCard.vue
@@ -19,7 +19,6 @@ defineProps<{
 <style lang="scss" scoped>
 .multi-card-group {
   display: grid;
-  grid-auto-rows: 1fr;
   grid-column-gap: 30px;
   grid-row-gap: 30px;
   grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));


### PR DESCRIPTION
The goal of this MR is to get rid of the egregious gaps between the cards on the main page when on mobile. 

<img width="906" height="1600" alt="image" src="https://github.com/user-attachments/assets/99c078a3-d32b-4059-bf81-32f7947f68f3" />
