### PR TITLE
Run `mix deps.get` before `mix mobilizon.instance.gen`

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ the local mobilizon instance.
 
 First run:
 ```
-mix mobilizon.instance gen
+mix dep.get                # Install elixir dependencies
+mix mobilizon.instance gen # Generate server configuration
 ```
 
 Then answer the following for the questions prompted:
@@ -197,7 +198,7 @@ The database is now installed and configured.
 ### Install and compile Elixir dependencies
 Ensure you are inside the Nix development shell (`nix develop` or via direnv).
 
-Install Elixir Dependencies:
+Install Elixir Dependencies (again):
 ```bash
 mix deps.get
 ```


### PR DESCRIPTION
Following the instructions I would get the following error running `mix mobilizon.instance.gen`

```
Unchecked dependencies for environment dev:
* icalendar (https://github.com/mobilizon-tools/icalendar.git)
  lock mismatch: the dependency is out of date. To fetch locked version run "mix deps.get"
** (Mix) Can't continue due to errors on dependencies
```

Running `mix deps.get` resolved it.