### PR TITLE
docs: add version control workflow to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,8 @@
 # Instructions for contributing to Klimatkalendern
+
+If you'd like to help out developing klimatkalendern.nu, or are generally interested in tools to facilitate movement organization, drop us an email at info@klimatkalendern.nu. 
+
 ## Version control workflow
-There are two long-lived branches: `main`, which builds the production site, and `dev`, which builds the test site.
-Feature branches are created as needed and continuously merged into `dev`. Direct pushes to `dev` are allowed but discouraged.
-`main` can only be changed by a PR from `dev`, this constitutes a release and requires approval from another maintainer.
+
+Klimatkalendern currently uses a two-trunk workflow. There are two long-lived branches: `main`, which builds the production site, and `dev`, which builds the test site.
+Feature branches are created as needed and merged into `dev`. Direct pushes to `dev` are allowed but discouraged. Pull requests into `dev` do not require review or approval (but feel free to request it). `main` can only be changed by a PR from `dev`, this constitutes a release and requires approval from another maintainer.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,5 @@
-Please read our full [contributing document](https://docs.mobilizon.org/4.%20Contribute/).
+# Instructions for contributing to Klimatkalendern
+## Version control workflow
+There are two long-lived branches: `main`, which builds the production site, and `dev`, which builds the test site.
+Feature branches are created as needed and continuously merged into `dev`. Direct pushes to `dev` are allowed but discouraged.
+`main` can only be changed by a PR from `dev`, this constitutes a release and requires approval from another maintainer.

--- a/README.md
+++ b/README.md
@@ -288,3 +288,15 @@ in the project directory to force a refresh of the environment.
 
 Your environment is now reset and you can follow the setup guide from
 step 2 under Postgresql ("Initial Postgres User and Database setup").
+
+
+## Following upstream mobilizon
+
+We strive to keep up to date with the [upstream repo](https://framagit.org/kaihuri/mobilizon). In order to ingest upstream changes, we follow the following procedure:
+
+1. Create a branch in our repo matching the release we want to ingest in upstream.
+2. In that branch make a merge commit merging in our *main* branch.
+3. Test deploy that branch in the development environment so see it works fine.
+3. Create a PR to merge that branch into main.
+
+The effect in the history should be one commit on top of *main* with the message "Merge Mobilizon vXX.XX" which has two parents - the previous main tip, and the merge commit that was made on the upstream branch.

--- a/README.md
+++ b/README.md
@@ -295,8 +295,9 @@ step 2 under Postgresql ("Initial Postgres User and Database setup").
 We strive to keep up to date with the [upstream repo](https://framagit.org/kaihuri/mobilizon). In order to ingest upstream changes, we follow the following procedure:
 
 1. Create a branch in our repo matching the release we want to ingest in upstream.
-2. In that branch make a merge commit merging in our *main* branch.
-3. Test deploy that branch in the development environment so see it works fine.
-3. Create a PR to merge that branch into main.
+2. Merge our `dev` into that branch, resolving any merge conflicts.
+3. Verify that the branch seems to work locally.
+5. Open a PR from that branch into `dev` and allow another maintainer to review the changes. Use a merge commit as a merging strategy. The effect in the history should be one commit on top of `dev` with the message "Merge Mobilizon vXX.XX" which has two parents - the previous dev tip, and the merge commit that was made on the upstream branch.
+6. After acceptance, as usual deploy from dev, see that it seems to work, and then make a deployment into `main`.
 
-The effect in the history should be one commit on top of *main* with the message "Merge Mobilizon vXX.XX" which has two parents - the previous main tip, and the merge commit that was made on the upstream branch.
+


### PR DESCRIPTION
This is suggestion on how to work with our dev and main deployments and feature branches. It formalizes the discussion we had IRL in august 2025 and the addition that was suggested here: https://github.com/Kompismoln/klimatkalendern/pull/29

It also closes a request for dev-env documentation https://github.com/Kompismoln/klimatkalendern/issues/38