### PR TITLE
refactor: Event card width

### DIFF
--- a/src/components/Event/EventCard.vue
+++ b/src/components/Event/EventCard.vue
@@ -3,13 +3,13 @@
     class="mbz-card snap-center dark:bg-mbz-purple h-full rounded-lg overflow-hidden"
     :class="{
       'sm:flex sm:items-start': mode === 'row',
-      'sm:max-w-xs w-[18rem] shrink-0 flex flex-col': mode === 'column',
+      'w-full shrink-0 flex flex-col': mode === 'column',
     }"
     :to="to"
     :isInternal="isInternal"
   >
     <div
-      :class="{ 'sm:w-full sm:max-w-[20rem]': mode === 'row' }"
+      :class="{ 'sm:w-full sm:max-w-[20rem] h-full': mode === 'row' }"
     >
       <div
         class="-mt-3 h-0 mb-3 ltr:ml-0 rtl:mr-0 block relative z-10 hidden"

--- a/src/components/Event/MultiCard.vue
+++ b/src/components/Event/MultiCard.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="grid gap-x-2 gap-y-4 md:gap-x-6 grid-cols-[repeat(auto-fill,_minmax(250px,_1fr))] justify-items-center"
+    class="grid gap-x-2 gap-y-4 md:gap-x-6 grid-cols-[repeat(auto-fill,_minmax(250px,_1fr))]"
   >
     <event-card
       class="flex flex-col h-full"

--- a/src/components/Local/CloseContent.vue
+++ b/src/components/Local/CloseContent.vue
@@ -21,7 +21,7 @@
     </div>
 
     <div
-      class="grid gap-x-2 gap-y-2 grid-cols-[repeat(auto-fill,_minmax(250px,_1fr))] justify-items-center"
+      class="grid gap-5 grid-cols-[repeat(auto-fill,_minmax(250px,_1fr))]"
     >
       <slot name="content" />
     </div>

--- a/src/components/Local/MoreContent.vue
+++ b/src/components/Local/MoreContent.vue
@@ -1,7 +1,7 @@
 <template>
   <router-link
     :to="to"
-    class="mbz-card flex flex-col items-center dark:border-gray-700 shadow-md md:flex-col snap-center shrink-0 first:pl-8 w-[18rem] dark:bg-mbz-purple"
+    class="mbz-card flex flex-col items-center dark:border-gray-700 shadow-md md:flex-col snap-center shrink-0 first:pl-8 dark:bg-mbz-purple"
   >
     <div class="relative w-full group">
       <img


### PR DESCRIPTION
This PR ensures that event cards always fill up the available horizontal space, and also increases the default event grid gap. Before this, especially on mobile, cards don't fill up the available space, leaving large column gaps.

## Previews 
<img width="1358" height="884" alt="image" src="https://github.com/user-attachments/assets/7761a6c6-ff9d-4542-9a4d-10a336080403" />
<img width="659" height="812" alt="image" src="https://github.com/user-attachments/assets/4d313021-d61d-4ce0-bc0d-dbf4a802f30a" />
