### PR TITLE
Remove too specific instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,8 +206,6 @@ Install Elixir Dependencies (again):
 mix deps.get
 ```
 
-If prompted to install `rebar3`, answer y (yes).
-
 **Compile the Application:**
 According to upstream documentation, some commands are run with `MIX_ENV=prod`
 the reason for this is unkown, we just do it because they do it.


### PR DESCRIPTION
Think mix deps.get asks to install all missing dependencies, and it depends on what is installed already